### PR TITLE
Rewrote procedural map renderer...

### DIFF
--- a/MapifyEditor/Procedural/MapRenderer.cs
+++ b/MapifyEditor/Procedural/MapRenderer.cs
@@ -25,13 +25,46 @@ namespace Mapify.Editor
             int terrainWidth = heightmapResolution - 1;
             int totalWidth = terrainWidth * Mathf.CeilToInt(Mathf.Sqrt(terrainCount));
 
-            Texture2D combinedTexture = new Texture2D(totalWidth, totalWidth, TextureFormat.RGBA32, false);
+            // Texture2D combinedTexture = new Texture2D(totalWidth, totalWidth, TextureFormat.RGBA32, false); // OLD
 
+            // The above line results in a texture large enough to crash the exporter on a large map,
+            // at least without turning down terrain tile heightmap resolution.
+            // Let's try something different. - Cvetka
+
+            int combinationSize = 16384; // per-side size of combinedTexture, now a fixed value
+            
+            // Find how small the tiles need to be to fit into a combinationSize width texture.
+            int maxTileSize = Mathf.CeilToInt(combinationSize / Mathf.CeilToInt(Mathf.Sqrt(terrainCount)));
+            //Debug.Log($"maxTileSize: {maxTileSize} ({combinationSize} / terrain width in tiles, rounded down???)");
+
+            // Find the largest power of 2 smaller than (or equal to) that for actual tile texture size target
+            int maxPermissibleRes = Mathf.FloorToInt(Mathf.Pow(2, Mathf.Floor(Mathf.Log(maxTileSize, 2))));
+            //Debug.Log($"maxPermissibleRes: {maxPermissibleRes} (size that tile heightmaps will attempt to be resized to)");
+
+            // how wide will combinedTexture actually be?
+            int scaledWidth = maxPermissibleRes * Mathf.CeilToInt(Mathf.Sqrt(terrainCount));
+            //Debug.Log($"scaledWidth: {scaledWidth} (px size of combinedTexture)");
+
+            // and NOW declare this
+            Texture2D combinedTexture = new Texture2D(scaledWidth, scaledWidth, TextureFormat.RGBA32, false);
+            //Debug.Log($"Verify that combinedTexure got iniialized to the correct size: {combinedTexture.height}");
+
+            // these are unchanged, but now measure in maxPermissibleRes instead of terrainWidth
             int currentX = 0;
             int currentY = 0;
-            Color[] colors = new Color[terrainWidth * terrainWidth];
+
+            // colors[] needs to still be the size (px count) of the tile heightmap so this is fine
+            Color[] colors = new Color[terrainWidth * terrainWidth]; // do not change
+
+
             for (int i = 0; i < terrainCount; i++)
             {
+                // I need a new texture to store the tile heightmap data into, per tile
+                Texture2D tempTexture = new Texture2D(terrainWidth, terrainWidth, TextureFormat.RGBA32, false);
+
+                // this block checks the heightmap of the tile pixel by pixel, figures out the correct map color at that
+                // spot, and saves that color into the array colors[] - The Worst Bitmap Format(TM).
+                // Anyway, sure, none of this changes.
                 Terrain terrain = terrains[i];
                 float terrainY = terrain.transform.position.y;
                 TerrainData terrainData = terrain.terrainData;
@@ -39,28 +72,54 @@ namespace Mapify.Editor
                 float[,] heightmapData = terrainData.GetHeights(0, 0, heightmapResolution, heightmapResolution);
 
                 for (int y = 0; y < terrainWidth; y++)
-                for (int x = 0; x < terrainWidth; x++)
-                {
-                    float height = heightmapData[y, x];
-                    float worldHeight = terrainY + height * terrainHeight;
-                    float waterLevel = worldHeight / mapInfo.waterLevel;
-                    float terrainLevel = worldHeight / (terrainY + terrainHeight);
-                    Color color = worldHeight <= mapInfo.waterLevel
-                        ? mapInfo.waterColor.Evaluate(float.IsNaN(waterLevel) ? 0.0f : waterLevel)
-                        : mapInfo.terrainColor.Evaluate(float.IsNaN(terrainLevel) ? 0.0f : terrainLevel);
-                    colors[y * terrainWidth + x] = color;
-                }
+                    for (int x = 0; x < terrainWidth; x++)
+                    {
+                        float height = heightmapData[y, x];
+                        float worldHeight = terrainY + height * terrainHeight;
+                        float waterLevel = worldHeight / mapInfo.waterLevel;
+                        float terrainLevel = worldHeight / (terrainY + terrainHeight);
+                        Color color = worldHeight <= mapInfo.waterLevel
+                            ? mapInfo.waterColor.Evaluate(float.IsNaN(waterLevel) ? 0.0f : waterLevel)
+                            : mapInfo.terrainColor.Evaluate(float.IsNaN(terrainLevel) ? 0.0f : terrainLevel);
+                        colors[y * terrainWidth + x] = color;
+                    }
 
-                combinedTexture.SetPixels(currentX, currentY, terrainWidth, terrainWidth, colors);
+                // OLD line:
+                // combinedTexture.SetPixels(currentX, currentY, terrainWidth, terrainWidth, colors);
 
-                currentX += terrainWidth;
+                // lay the heightmap colors into the tempTexture
+                // and don't forget to Apply() it, because Graphics.Blit runs on the GPU, not the CPU
+                tempTexture.SetPixels(0, 0, terrainWidth, terrainWidth, colors);
+                tempTexture.Apply();
 
-                if (currentX + terrainWidth <= totalWidth)
+                // Now use a RenderTexture to scale the image down to match maxPermissibleRes
+                RenderTexture rtt = RenderTexture.GetTemporary(maxPermissibleRes, maxPermissibleRes, 0);
+                Graphics.Blit(tempTexture, rtt, new Material(Shader.Find("Hidden/BlitCopy")));
+                //Debug.Log($"RenderTexture rtt: {rtt.width}");
+                Texture2D tempScaledTexture = new Texture2D(maxPermissibleRes, maxPermissibleRes, TextureFormat.RGBA32, false);
+                tempScaledTexture.ReadPixels(new Rect(0, 0, maxPermissibleRes, maxPermissibleRes), 0, 0);
+                RenderTexture.ReleaseTemporary(rtt);
+
+
+                // now copy THAT image into where it goes within combinedTexture.
+                Graphics.CopyTexture(tempScaledTexture, 0, 0, 0, 0, maxPermissibleRes, maxPermissibleRes, combinedTexture, 0, 0, currentX, currentY);
+
+                //Debug.Log($"Tile iteration: i = {i}, currentX = {currentX}, currentY = {currentY}," +
+                //    $"tempTexture.width = {tempTexture.width}, first pixel {tempTexture.GetPixel(0,0)}," +
+                //    $"tempScaledTexture.width = {tempScaledTexture.width}, first pixel {tempScaledTexture.GetPixel(0,0)}");
+
+                // The rest of this block steps to the next terrain tile; basically unchanged, but
+                // now runs on maxPermissibleRes instead of terrainWidth, and scaledWidth instead of totalWidth.
+                currentX += maxPermissibleRes;
+                if (currentX + maxPermissibleRes <= scaledWidth)
                     continue;
-
                 currentX = 0;
-                currentY += terrainWidth;
+                currentY += maxPermissibleRes;
             }
+
+            //Debug.Log($"end of CreateHeightmap; combinedTexture first pixel: {combinedTexture.GetPixel(0,0)}");
+
+            // end of Cvetka's edits
 
             combinedTexture.Apply();
 

--- a/MapifyEditor/Procedural/MapRenderer.cs
+++ b/MapifyEditor/Procedural/MapRenderer.cs
@@ -1,6 +1,5 @@
 #if UNITY_EDITOR
 using System.Collections.Generic;
-using Mapify.Editor.Utils;
 using UnityEngine;
 
 namespace Mapify.Editor
@@ -23,31 +22,21 @@ namespace Mapify.Editor
 
             int heightmapResolution = terrains[0].terrainData.heightmapResolution;
             int terrainWidth = heightmapResolution - 1;
-            int totalWidth = terrainWidth * Mathf.CeilToInt(Mathf.Sqrt(terrainCount));
 
-            // Texture2D combinedTexture = new Texture2D(totalWidth, totalWidth, TextureFormat.RGBA32, false); // OLD
-
-            // The above line results in a texture large enough to crash the exporter on a large map,
-            // at least without turning down terrain tile heightmap resolution.
-            // Let's try something different. - Cvetka
-
+            // beginning of function rewrite that doesn't crash when processing combined heightmaps larger than 16k wide:
             int combinationSize = 16384; // per-side size of combinedTexture, now a fixed value
             
             // Find how small the tiles need to be to fit into a combinationSize width texture.
             int maxTileSize = Mathf.CeilToInt(combinationSize / Mathf.CeilToInt(Mathf.Sqrt(terrainCount)));
-            //Debug.Log($"maxTileSize: {maxTileSize} ({combinationSize} / terrain width in tiles, rounded down???)");
 
             // Find the largest power of 2 smaller than (or equal to) that for actual tile texture size target
             int maxPermissibleRes = Mathf.FloorToInt(Mathf.Pow(2, Mathf.Floor(Mathf.Log(maxTileSize, 2))));
-            //Debug.Log($"maxPermissibleRes: {maxPermissibleRes} (size that tile heightmaps will attempt to be resized to)");
 
             // how wide will combinedTexture actually be?
             int scaledWidth = maxPermissibleRes * Mathf.CeilToInt(Mathf.Sqrt(terrainCount));
-            //Debug.Log($"scaledWidth: {scaledWidth} (px size of combinedTexture)");
 
-            // and NOW declare this
+            // now declare this with the actual combined size
             Texture2D combinedTexture = new Texture2D(scaledWidth, scaledWidth, TextureFormat.RGBA32, false);
-            //Debug.Log($"Verify that combinedTexure got iniialized to the correct size: {combinedTexture.height}");
 
             // these are unchanged, but now measure in maxPermissibleRes instead of terrainWidth
             int currentX = 0;
@@ -62,9 +51,9 @@ namespace Mapify.Editor
                 // I need a new texture to store the tile heightmap data into, per tile
                 Texture2D tempTexture = new Texture2D(terrainWidth, terrainWidth, TextureFormat.RGBA32, false);
 
-                // this block checks the heightmap of the tile pixel by pixel, figures out the correct map color at that
+                // This block checks the heightmap of the tile pixel by pixel, figures out the correct map color at that
                 // spot, and saves that color into the array colors[] - The Worst Bitmap Format(TM).
-                // Anyway, sure, none of this changes.
+                // None of this changes.
                 Terrain terrain = terrains[i];
                 float terrainY = terrain.transform.position.y;
                 TerrainData terrainData = terrain.terrainData;
@@ -72,6 +61,7 @@ namespace Mapify.Editor
                 float[,] heightmapData = terrainData.GetHeights(0, 0, heightmapResolution, heightmapResolution);
 
                 for (int y = 0; y < terrainWidth; y++)
+                {
                     for (int x = 0; x < terrainWidth; x++)
                     {
                         float height = heightmapData[y, x];
@@ -83,43 +73,27 @@ namespace Mapify.Editor
                             : mapInfo.terrainColor.Evaluate(float.IsNaN(terrainLevel) ? 0.0f : terrainLevel);
                         colors[y * terrainWidth + x] = color;
                     }
-
-                // OLD line:
-                // combinedTexture.SetPixels(currentX, currentY, terrainWidth, terrainWidth, colors);
+                }
 
                 // lay the heightmap colors into the tempTexture
-                // and don't forget to Apply() it, because Graphics.Blit runs on the GPU, not the CPU
-                tempTexture.SetPixels(0, 0, terrainWidth, terrainWidth, colors);
+                // and don't forget to Apply() it, because Graphics.Blit() runs on the GPU, not the CPU
+                tempTexture.SetPixels(colors);
                 tempTexture.Apply();
 
-                // Now use a RenderTexture to scale the image down to match maxPermissibleRes
-                RenderTexture rtt = RenderTexture.GetTemporary(maxPermissibleRes, maxPermissibleRes, 0);
-                Graphics.Blit(tempTexture, rtt, new Material(Shader.Find("Hidden/BlitCopy")));
-                //Debug.Log($"RenderTexture rtt: {rtt.width}");
-                Texture2D tempScaledTexture = new Texture2D(maxPermissibleRes, maxPermissibleRes, TextureFormat.RGBA32, false);
-                tempScaledTexture.ReadPixels(new Rect(0, 0, maxPermissibleRes, maxPermissibleRes), 0, 0);
-                RenderTexture.ReleaseTemporary(rtt);
-
+                // This sets up a RenderTexture and calls Graphics.Blit() so that I don't need to. Keep your code DRY, Cvetka.
+                Texture2D tempScaledTexture = Resize(tempTexture, maxPermissibleRes, maxPermissibleRes);
 
                 // now copy THAT image into where it goes within combinedTexture.
                 Graphics.CopyTexture(tempScaledTexture, 0, 0, 0, 0, maxPermissibleRes, maxPermissibleRes, combinedTexture, 0, 0, currentX, currentY);
 
-                //Debug.Log($"Tile iteration: i = {i}, currentX = {currentX}, currentY = {currentY}," +
-                //    $"tempTexture.width = {tempTexture.width}, first pixel {tempTexture.GetPixel(0,0)}," +
-                //    $"tempScaledTexture.width = {tempScaledTexture.width}, first pixel {tempScaledTexture.GetPixel(0,0)}");
-
-                // The rest of this block steps to the next terrain tile; basically unchanged, but
-                // now runs on maxPermissibleRes instead of terrainWidth, and scaledWidth instead of totalWidth.
+                // The rest of this block steps to the next terrain tile; basically unchanged, but now runs on maxPermissibleRes instead of
+                // terrainWidth, and scaledWidth instead of totalWidth (which is no longer used at all and has been removed.)
                 currentX += maxPermissibleRes;
                 if (currentX + maxPermissibleRes <= scaledWidth)
                     continue;
                 currentX = 0;
                 currentY += maxPermissibleRes;
             }
-
-            //Debug.Log($"end of CreateHeightmap; combinedTexture first pixel: {combinedTexture.GetPixel(0,0)}");
-
-            // end of Cvetka's edits
 
             combinedTexture.Apply();
 


### PR DESCRIPTION
...to handle any arbitrary terrain size and heightmap resolution. Tested at default 513x513 heightmap resolution with terrains from 3km up to 20km wide, with no problems.